### PR TITLE
fix(asciidoc): dependency versions for @forastro/asciidoc in package.json

### DIFF
--- a/packages/asciidoc/package.json
+++ b/packages/asciidoc/package.json
@@ -16,8 +16,8 @@
     "slugify": "^1.6.6"
   },
   "optionalDependencies": {
-    "unocss": "=>0.65.0",
-    "tailwindcss": "=>3.2.0"
+    "unocss": ">=0.65.0",
+    "tailwindcss": ">=3.2.0"
   },
   "type": "module",
   "main": "./src/index.ts",


### PR DESCRIPTION
It seems like optional dependencies "unocss" and  "tailwindcss" in `packages/asciidoc/package.json` are currently using incorrect version syntax (`"=>1.1.1"` instead of `">=1.1.1"`), which makes npm fail when installing it with the following error:
```
32 error code EINVALIDTAGNAME
33 error Invalid tag name "=>0.65.0" of package "unocss@=>0.65.0": Tags may not have any characters that encodeURIComponent encodes.
```