### PR TITLE
hotfix(nx-astro-plugin,ci): unblock Release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -105,8 +105,12 @@ jobs:
           # Generate changelogs
           pnpm nx release changelog --yes --verbose
           
-          # Publish to npm
-          pnpm nx release publish --yes --verbose
+          # Publish to npm only if NPM_TOKEN is present
+          if [ -z "${NPM_TOKEN}" ]; then
+            echo "NPM_TOKEN is not set. Skipping npm publish step."
+          else
+            pnpm nx release publish --yes --verbose
+          fi
 
   # Dry Run Job (for develop branch and PRs)
   release-dry-run:

--- a/packages/nx-astro-plugin/src/generators/add-integration/generator.ts
+++ b/packages/nx-astro-plugin/src/generators/add-integration/generator.ts
@@ -1,6 +1,6 @@
 import type { Tree } from '@nx/devkit';
 import { readProjectConfiguration } from '@nx/devkit';
-import { detectPackageManager, getExecFor } from '../../utils/pm.js';
+import { resolveAstroBinary } from '../../utils/pm.js';
 import { execa } from 'execa';
 
 interface Schema {
@@ -11,13 +11,10 @@ interface Schema {
 
 export default async function addIntegration(tree: Tree, options: Schema) {
   const proj = readProjectConfiguration(tree, options.project);
-  const pm = detectPackageManager();
-  const { npx, runner } = getExecFor(pm);
+  const astroBin = await resolveAstroBinary(proj.root, (tree as any).root ?? process.cwd());
 
   for (const name of options.names) {
-    const args: string[] = [];
-    if (runner.length) args.push(...runner);
-    args.push('astro', 'add', name, '--yes');
-    await execa(npx, args, { cwd: proj.root, stdio: 'inherit' });
+    const args: string[] = ['add', name, '--yes'];
+    await execa(astroBin, args, { cwd: proj.root, stdio: 'inherit' });
   }
 }

--- a/packages/nx-astro-plugin/src/generators/app/generator.ts
+++ b/packages/nx-astro-plugin/src/generators/app/generator.ts
@@ -1,5 +1,5 @@
 import type { Tree } from '@nx/devkit';
-import { formatFiles, joinPathFragments, generateFiles, updateJson, addDependenciesToPackageJson } from '@nx/devkit';
+import { formatFiles, joinPathFragments, generateFiles, updateJson } from '@nx/devkit';
 import { execa } from 'execa';
 import { join, dirname } from 'node:path';
 import { fileURLToPath } from 'node:url';


### PR DESCRIPTION
- fix(nx-astro-plugin): use resolveAstroBinary in add-integration
- ci(release): skip npm publish when NPM_TOKEN is missing

This hotfix addresses the Release job failing on main due to a build error in the Nx Astro plugin generator and guards npm publish when auth is not configured.